### PR TITLE
CORE-1738: wireless_watcher dies

### DIFF
--- a/wireless_watcher/nodes/watcher_node
+++ b/wireless_watcher/nodes/watcher_node
@@ -26,22 +26,29 @@ class Connection(wireless_msgs.msg.Connection):
     def __init__(self, fields):
         args = {}
 
-        args['bitrate'] = trim(fields['Bit Rate'], float)
+        try: args['bitrate'] = trim(fields['Bit Rate'], float)
+        except: pass
 
         try: args['txpower'] = trim(fields['Tx-Power'])
         except: pass
 
-        args['link_quality_raw'] = fields['Link Quality']
-        num, den = re.split('/', args['link_quality_raw']) 
-        args['link_quality'] = float(num) / float(den)
-
-        args['signal_level'] = trim(fields['Signal level'])
+        try: 
+          args['link_quality_raw'] = fields['Link Quality']
+          num, den = re.split('/', args['link_quality_raw'])
+          args['link_quality'] = float(num) / float(den)
+        except: pass
+        
+        try: args['signal_level'] = trim(fields['Signal level'])
+        except: pass
 
         try: args['noise_level'] = trim(fields['Noise level'])
         except: pass
 
-        args['essid'] = fields['ESSID'].strip('"')
-        args['bssid'] = fields['Access Point'].strip()
+        try: args['essid'] = fields['ESSID'].strip('"')
+        except: pass
+
+        try: args['bssid'] = fields['Access Point'].strip()
+        except: pass
 
         super(Connection, self).__init__(**args)
 

--- a/wireless_watcher/nodes/watcher_node
+++ b/wireless_watcher/nodes/watcher_node
@@ -26,28 +26,17 @@ class Connection(wireless_msgs.msg.Connection):
     def __init__(self, fields):
         args = {}
 
-        try: args['bitrate'] = trim(fields['Bit Rate'], float)
-        except: pass
+        args['bitrate'] = trim(fields.get('Bit Rate', "0.0"), float)
+        args['txpower'] = trim(fields.get('Tx-Power', "0"))
+        args['signal_level'] = trim(fields.get('Signal level', "0"))
+        args['noise_level'] = trim(fields.get('Noise level', "0"))
+        args['essid'] = fields.get('ESSID', "").strip('"')
+        args['bssid'] = fields.get('Access Point', "").strip()
 
-        try: args['txpower'] = trim(fields['Tx-Power'])
-        except: pass
-
-        try: 
+        try:
           args['link_quality_raw'] = fields['Link Quality']
           num, den = re.split('/', args['link_quality_raw'])
           args['link_quality'] = float(num) / float(den)
-        except: pass
-        
-        try: args['signal_level'] = trim(fields['Signal level'])
-        except: pass
-
-        try: args['noise_level'] = trim(fields['Noise level'])
-        except: pass
-
-        try: args['essid'] = fields['ESSID'].strip('"')
-        except: pass
-
-        try: args['bssid'] = fields['Access Point'].strip()
         except: pass
 
         super(Connection, self).__init__(**args)
@@ -79,8 +68,12 @@ while not rospy.is_shutdown():
     fields_list = [re.split('[:=]', field_str, maxsplit=1) for field_str in fields_str]
     fields_dict = { 'dev': fields_str[0], 'type': fields_str[1] }
     fields_dict.update(dict([field for field in fields_list if len(field) == 2 ]))
-    #print fields_dict
-    connection_msg = Connection(fields_dict)
+
+    # Check if WiFi is connected to a network
+    connection_msg = {}
+    if "Not-Associated" not in fields_dict['Access Point']:
+      connection_msg = Connection(fields_dict)
+
     connection_pub.publish(connection_msg)
 
     if not previous_success:


### PR DESCRIPTION
If the wifi is not connected to any network, the wireless_watcher node crashes as it's not able to parse the 'Bit Rate' and other fields. I just added a try block for each field, although I'm not sure if this is the best way to do this..