### PR TITLE
CORE-1738: wireless watcher dies - queue_size update

### DIFF
--- a/wireless_watcher/nodes/watcher_node
+++ b/wireless_watcher/nodes/watcher_node
@@ -47,12 +47,12 @@ class Network(wireless_msgs.msg.Network):
         super(Network, self).__init__(**args)
 
 
-connection_pub = rospy.Publisher('connection', Connection)
+connection_pub = rospy.Publisher('connection', Connection, queue_size=1)
 
 # Disable this until we actually collect and publish the data.
 # network_pub = rospy.Publisher('network', Network)
 
-connected_pub = rospy.Publisher('connected', std_msgs.msg.Bool)
+connected_pub = rospy.Publisher('connected', std_msgs.msg.Bool, queue_size=1)
 
 while not rospy.is_shutdown():
   try:


### PR DESCRIPTION
Gets rid of the: `"SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'"` messages. @abencz 