### PR TITLE
Improve connected detection logic so topic doesn't stop when interface is down

### DIFF
--- a/wireless_watcher/nodes/watcher_node
+++ b/wireless_watcher/nodes/watcher_node
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD)
 #
 # @author    Mike Purvis <mpurvis@clearpath.ai>
@@ -93,10 +93,9 @@ def main():
 
     while not rospy.is_shutdown():
         try:
-            ip_str = subprocess.check_output(['ip', 'addr', 'show', dev], stderr=subprocess.STDOUT)
-            if re.search(b'^\s*inet\s', ip_str, re.MULTILINE):
-                connected_pub.publish(True)
-        except subprocess.CalledProcessError:
+            with open(os.path.join(SYS_NET_PATH, dev, 'operstate'), 'rb') as f:
+                connected_pub.publish(f.read().strip() == b'up')
+        except FileNotFoundError:
             connected_pub.publish(False)
 
         try:


### PR DESCRIPTION
There are a couple of problems with the `connected` detection logic,

1. It looks for an IP address so in the case where a static IP is assigned to the WiFi interface, the node publishes `connected` as `True` even if the robot is not connected to an AP. 
2. If the regex search fails, say the interface is down, there is no `else` statement to publish `False` so it just stops publishing when the interface goes down.

In this MR, I have changed it to use `operstate` from `/sys/class/net` instead.