### PR TITLE
Add wireless-tools as a dependency

### DIFF
--- a/wireless_watcher/package.xml
+++ b/wireless_watcher/package.xml
@@ -12,4 +12,5 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>wireless_msgs</exec_depend>
+  <exec_depend>wireless-tools</exec_depend>
 </package>


### PR DESCRIPTION
Wireless-tools appears to be a necessary dependency on Noetic and Melodic; without the package installed [this line](https://github.com/clearpathrobotics/wireless/blob/782d567a9cd6ae9e0366f8d5f71ecf3bde0cb644/wireless_watcher/nodes/watcher_node#L102) will fail.