### PR TITLE
[wireless_watcher] Switched to underscores to get rid of usage of das…

### DIFF
--- a/wireless_watcher/setup.cfg
+++ b/wireless_watcher/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/wireless_watcher
+script_dir=$base/lib/wireless_watcher
 [install]
-install-scripts=$base/lib/wireless_watcher
+install_scripts=$base/lib/wireless_watcher


### PR DESCRIPTION
…h-separated warning:

```
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
```