### PR TITLE
Define static type in template

### DIFF
--- a/wireless_watcher/src/wireless_watcher.cpp
+++ b/wireless_watcher/src/wireless_watcher.cpp
@@ -169,7 +169,7 @@ WirelessWatcher::WirelessWatcher() : rclcpp::Node("wireless_watcher") {
 std::string WirelessWatcher::exec_cmd(const std::string& cmd) {
     std::array<char, 128> buffer;
     std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
     if (!pipe) {
         throw std::runtime_error("popen() failed!");
     }


### PR DESCRIPTION
Throws a warning when building with Jazzy default CMakeLists